### PR TITLE
Add boolean flag to control DG2 read

### DIFF
--- a/core-lib/src/main/java/org/idpass/smartscanner/lib/nfc/details/NFCDocumentTag.kt
+++ b/core-lib/src/main/java/org/idpass/smartscanner/lib/nfc/details/NFCDocumentTag.kt
@@ -38,7 +38,7 @@ import org.jmrtd.lds.icao.MRZInfo
 import java.security.Security
 
 
-class NFCDocumentTag {
+class NFCDocumentTag(val readDG2: Boolean = true) {
 
     fun handleTag(context: Context, tag: Tag, mrzInfo: MRZInfo, mrtdTrustStore: MRTDTrustStore, passportCallback: PassportCallback):Disposable{
         return  Single.fromCallable {
@@ -61,7 +61,7 @@ class NFCDocumentTag {
                 })
                 ps.open()
 
-                val passportNFC = PassportNFC(ps, mrtdTrustStore, mrzInfo)
+                val passportNFC = PassportNFC(ps, mrtdTrustStore, mrzInfo, readDG2)
                 val verifySecurity = passportNFC.verifySecurity()
                 val features = passportNFC.features
 
@@ -89,7 +89,7 @@ class NFCDocumentTag {
                 }
 
                 //Picture
-                if (passportNFC.dg2File != null) {
+                if (passportNFC.dg2File != null && passportNFC.readDG2) {
                     //Get the picture
                     try {
                         val faceImage = PassportNfcUtils.retrieveFaceImage(context, passportNFC.dg2File!!)

--- a/core-lib/src/main/java/org/idpass/smartscanner/lib/nfc/passport/PassportNFC.kt
+++ b/core-lib/src/main/java/org/idpass/smartscanner/lib/nfc/passport/PassportNFC.kt
@@ -52,6 +52,8 @@ import javax.security.auth.x500.X500Principal
 class PassportNFC @Throws(GeneralSecurityException::class)
 private constructor() {
 
+    var readDG2 = true
+
     /** The hash function for DG hashes.  */
     private var digest: MessageDigest? = null
 
@@ -212,7 +214,8 @@ private constructor() {
      * @throws GeneralSecurityException if certain security primitives are not supported
      */
     @Throws(CardServiceException::class, GeneralSecurityException::class)
-    constructor(ps: PassportService?, trustManager: MRTDTrustStore, mrzInfo: MRZInfo) : this() {
+    constructor(ps: PassportService?, trustManager: MRTDTrustStore, mrzInfo: MRZInfo, readDG2: Boolean = true) : this() {
+        this.readDG2 = readDG2
         if (ps == null) {
             throw IllegalArgumentException("Service cannot be null")
         }
@@ -1047,7 +1050,7 @@ private constructor() {
                 return dg1File
             }
             2 -> {
-                return dg2File
+                return if (readDG2) dg2File else null
             }
             3 -> {
                 return dg3File


### PR DESCRIPTION
## Issue

For [issue#70](https://github.com/idpass/smartscanner-core/issues/70) adding a flag to read DG2 or not.

#[70] [Add flag to read e-passport photoAdd flag to read e-passport photo]

## Changes

The existing code base has an inherent logic that deals when a read permission is not satisfied and as a result, a data group is unreadable. Inserting the new flag into this logic results in a minimal change.  

1. Pass a boolean flag to the `NFCDocumentTag` constructor [here](https://github.com/idpass/smartscanner-core/blob/develop/core-lib/src/main/java/org/idpass/smartscanner/lib/nfc/NFCFragment.kt#L108)
2. The flag will propagate to `PassportNFC` instance
3. The flag is used in `PassportNFC::getDG( )` method to control the `DG2` read. 

The `verifyHash()` will skip the hash check for `DG2`  (ie, modified flow will not read DG2) in use cases where the photo from `DG2` is not needed. For other cases where the photo is retrieved (because it needs to be displayed in a UI), then `verifyHash()` will read `DG2` to calculate its value and compare (ie, original flow).