### PR TITLE
NameOfHolder and NFC Screen being null Issues

### DIFF
--- a/core-lib/src/main/java/org/idpass/smartscanner/lib/nfc/NFCFragment.kt
+++ b/core-lib/src/main/java/org/idpass/smartscanner/lib/nfc/NFCFragment.kt
@@ -76,7 +76,7 @@ class  NFCFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         val arguments = arguments
         if (arguments?.containsKey(IntentData.KEY_MRZ_INFO) == true) {
-            mrzInfo = arguments.getSerializable(IntentData.KEY_MRZ_INFO) as MRZInfo
+            mrzInfo = arguments.getSerializable(IntentData.KEY_MRZ_INFO) as MRZInfo?
         }
         if (arguments?.containsKey(IntentData.KEY_LOCALE) == true) {
             locale = arguments.getString(IntentData.KEY_LOCALE)
@@ -244,7 +244,7 @@ class  NFCFragment : Fragment() {
         init {
             Security.insertProviderAt(BouncyCastleProvider(), 1)
         }
-        fun newInstance(mrzInfo: MRZInfo, language: String?, locale : String?, withPhoto: Boolean): NFCFragment {
+        fun newInstance(mrzInfo: MRZInfo?, language: String?, locale : String?, withPhoto: Boolean): NFCFragment {
             val myFragment = NFCFragment()
             val args = Bundle()
             args.putSerializable(IntentData.KEY_MRZ_INFO, mrzInfo)

--- a/core-lib/src/main/res/layout/fragment_passport_details.xml
+++ b/core-lib/src/main/res/layout/fragment_passport_details.xml
@@ -49,7 +49,6 @@
                         android:layout_alignParentTop="true"
                         android:layout_marginStart="@dimen/margin_small"
                         android:layout_marginEnd="@dimen/margin_small"
-                        android:layout_marginBottom="@dimen/margin_small"
                         android:layout_toEndOf="@+id/iconWarning"
                         android:text="@string/document_valid_passport"
                         android:textColor="@color/white" />


### PR DESCRIPTION
## Issue

#68 NameOfHolder and NFC Screen being null Issues 

## Changes

<!-- Provide a detailed description of the changes proposed in this PR -->

- Fix NullPointerExceptions when NFCFragment is loaded
- Fix mrz string passed when MRZInfo is being initialized
- Add Finally block to always initialize MRZInfo for NFC Scanning 
- Addressed NameOfHolder not displaying properly
