### PR TITLE
Option for NFC Reader label to be configurable

### DIFF
--- a/core-lib/src/main/java/org/idpass/smartscanner/lib/SmartScannerActivity.kt
+++ b/core-lib/src/main/java/org/idpass/smartscanner/lib/SmartScannerActivity.kt
@@ -239,6 +239,7 @@ class SmartScannerActivity : BaseActivity(), OnClickListener {
                         intent = intent,
                         isMLKit = isMLKit,
                         imageResultType = config?.imageResultType ?: ImageResultType.PATH.value,
+                        label = nfcOptions?.label,
                         language = scannerOptions?.language ?: intent.getStringExtra(ScannerConstants.LANGUAGE),
                         locale = nfcOptions?.locale ?: intent.getStringExtra(ScannerConstants.NFC_LOCALE),
                         withPhoto = nfcOptions?.withPhoto ?: true, // default is true, NFC results with photo

--- a/core-lib/src/main/java/org/idpass/smartscanner/lib/mrz/MRZAnalyzer.kt
+++ b/core-lib/src/main/java/org/idpass/smartscanner/lib/mrz/MRZAnalyzer.kt
@@ -48,6 +48,7 @@ open class MRZAnalyzer(
         override val intent: Intent,
         override val mode: String = Modes.MRZ.value,
         private val language: String? = null,
+        private val label: String? = null,
         private val locale: String? = null,
         private val withPhoto: Boolean? = null,
         private val enableLogging: Boolean? = null,

--- a/core-lib/src/main/java/org/idpass/smartscanner/lib/nfc/NFCActivity.kt
+++ b/core-lib/src/main/java/org/idpass/smartscanner/lib/nfc/NFCActivity.kt
@@ -71,8 +71,9 @@ class NFCActivity : FragmentActivity(), NFCFragment.NfcFragmentListener, Passpor
     private var mrzInfo: MRZInfo? = null
     private var nfcAdapter: NfcAdapter? = null
     private var pendingIntent: PendingIntent? = null
-    private var locale: String? = null
+    private var label: String? = null
     private var language: String? = null
+    private var locale: String? = null
     private var withPhoto: Boolean = true
     private var enableLogging: Boolean = false
 
@@ -86,9 +87,10 @@ class NFCActivity : FragmentActivity(), NFCFragment.NfcFragmentListener, Passpor
         // fetch data from intent
         language = intent.getStringExtra(ScannerConstants.LANGUAGE)
         locale = intent.getStringExtra(ScannerConstants.NFC_LOCALE)
+        label = intent.getStringExtra(IntentData.KEY_LABEL)
         withPhoto = intent.getBooleanExtra(IntentData.KEY_WITH_PHOTO, true)
-        enableLogging = intent.getBooleanExtra(IntentData.KEY_ENABLE_LOGGGING, true)
-        // setup logs
+        enableLogging = intent.getBooleanExtra(IntentData.KEY_ENABLE_LOGGGING, false)
+        // setup logs, only available for debug builds
         if (BuildConfig.DEBUG && enableLogging) {
             setupLogs()
         }
@@ -111,7 +113,7 @@ class NFCActivity : FragmentActivity(), NFCFragment.NfcFragmentListener, Passpor
         super.onResume()
         if (nfcAdapter != null && nfcAdapter?.isEnabled == true) {
             pendingIntent = PendingIntent.getActivity(this, 0,
-                    Intent(this, this.javaClass).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP), 0)
+                Intent(this, this.javaClass).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP), 0)
         } else checkNFC()
     }
 
@@ -135,7 +137,7 @@ class NFCActivity : FragmentActivity(), NFCFragment.NfcFragmentListener, Passpor
         if (mrzInfo != null) {
             supportFragmentManager.beginTransaction()
                     .replace(R.id.container,
-                            NFCFragment.newInstance(mrzInfo = mrzInfo, language = language, locale = locale, withPhoto = withPhoto), TAG_NFC)
+                            NFCFragment.newInstance(mrzInfo = mrzInfo, label = label, language = language, locale = locale, withPhoto = withPhoto), TAG_NFC)
                     .commit()
         }
     }

--- a/core-lib/src/main/java/org/idpass/smartscanner/lib/nfc/NFCFragment.kt
+++ b/core-lib/src/main/java/org/idpass/smartscanner/lib/nfc/NFCFragment.kt
@@ -51,7 +51,7 @@ import java.security.Security
 import java.util.*
 
 
-class  NFCFragment : Fragment() {
+class NFCFragment : Fragment() {
 
     private var mrzInfo: MRZInfo? = null
     private var nfcFragmentListener: NfcFragmentListener? = null
@@ -60,6 +60,7 @@ class  NFCFragment : Fragment() {
     private var textViewDateOfBirth: TextView? = null
     private var textViewDateOfExpiry: TextView? = null
     private var progressBar: ProgressBar? = null
+    private var label: String? = null
     private var language: String? = null
     private var locale: String? = null
     private var withPhoto: Boolean = true
@@ -77,6 +78,9 @@ class  NFCFragment : Fragment() {
         val arguments = arguments
         if (arguments?.containsKey(IntentData.KEY_MRZ_INFO) == true) {
             mrzInfo = arguments.getSerializable(IntentData.KEY_MRZ_INFO) as MRZInfo?
+        }
+        if (arguments?.containsKey(IntentData.KEY_LABEL) == true) {
+            label = arguments.getString(IntentData.KEY_LABEL)
         }
         if (arguments?.containsKey(IntentData.KEY_LOCALE) == true) {
             locale = arguments.getString(IntentData.KEY_LOCALE)
@@ -104,7 +108,7 @@ class  NFCFragment : Fragment() {
         val keyStore = KeyStoreUtils().readKeystoreFromFile(cscaInputStream)
 
         val mrtdTrustStore = MRTDTrustStore()
-        if (keyStore!=null) {
+        if (keyStore != null) {
             val certStore = KeyStoreUtils().toCertStore(keyStore = keyStore)
             mrtdTrustStore.addAsCSCACertStore(certStore)
         }
@@ -180,7 +184,7 @@ class  NFCFragment : Fragment() {
         // Display proper language
         LanguageUtils.changeLanguage(requireContext(), if (language == Language.EN) Language.EN else Language.AR)
         // Display MRZ details
-        textViewNfcTitle?.text = getString(R.string.nfc_title)
+        textViewNfcTitle?.text = if (label != null) label else getString(R.string.nfc_title)
         textViewPassportNumber?.text = getString(R.string.doc_number, mrzInfo?.documentNumber)
         textViewDateOfBirth?.text = getString(R.string.doc_dob, DateUtils.toAdjustedDate(formatStandardDate(mrzInfo?.dateOfBirth)))
         textViewDateOfExpiry?.text = getString(R.string.doc_expiry, DateUtils.toReadableDate(formatStandardDate(mrzInfo?.dateOfExpiry)))
@@ -244,10 +248,12 @@ class  NFCFragment : Fragment() {
         init {
             Security.insertProviderAt(BouncyCastleProvider(), 1)
         }
-        fun newInstance(mrzInfo: MRZInfo?, language: String?, locale : String?, withPhoto: Boolean): NFCFragment {
+
+        fun newInstance(mrzInfo: MRZInfo?, label: String?, language: String?, locale: String?, withPhoto: Boolean): NFCFragment {
             val myFragment = NFCFragment()
             val args = Bundle()
             args.putSerializable(IntentData.KEY_MRZ_INFO, mrzInfo)
+            args.putString(IntentData.KEY_LABEL, label)
             args.putString(IntentData.KEY_LANGUAGE, language)
             args.putString(IntentData.KEY_LOCALE, locale)
             args.putBoolean(IntentData.KEY_WITH_PHOTO, withPhoto)

--- a/core-lib/src/main/java/org/idpass/smartscanner/lib/nfc/NFCScanAnalyzer.kt
+++ b/core-lib/src/main/java/org/idpass/smartscanner/lib/nfc/NFCScanAnalyzer.kt
@@ -34,6 +34,7 @@ open class NFCScanAnalyzer(
     override val activity: Activity,
     override val intent: Intent,
     override val mode: String = Modes.NFC_SCAN.value,
+    private val label: String?,
     private val language: String?,
     private val locale: String?,
     private val withPhoto: Boolean,
@@ -44,7 +45,7 @@ open class NFCScanAnalyzer(
     analyzeStart: Long,
     onConnectSuccess: (String) -> Unit,
     onConnectFail: (String) -> Unit
-) : MRZAnalyzer(activity, intent, mode, language, locale, withPhoto, enableLogging, isMLKit, imageResultType, format, analyzeStart, onConnectSuccess, onConnectFail) {
+) : MRZAnalyzer(activity, intent, mode, label, language, locale, withPhoto, enableLogging, isMLKit, imageResultType, format, analyzeStart, onConnectSuccess, onConnectFail) {
 
     override fun processResult(result: String, bitmap: Bitmap, rotation: Int) {
         val mrzResult =  MRZResult.formatMrzResult(MRZCleaner.parseAndClean(result))
@@ -59,6 +60,7 @@ open class NFCScanAnalyzer(
             nfcIntent.putExtra(ScannerConstants.NFC_MRZ_STRING, mrzString)
             nfcIntent.putExtra(ScannerConstants.NFC_LOCALE, locale)
             nfcIntent.putExtra(ScannerConstants.LANGUAGE, language)
+            nfcIntent.putExtra(IntentData.KEY_LABEL, label)
             nfcIntent.putExtra(IntentData.KEY_WITH_PHOTO, withPhoto)
             nfcIntent.putExtra(IntentData.KEY_ENABLE_LOGGGING, enableLogging)
             nfcIntent.addFlags(Intent.FLAG_ACTIVITY_FORWARD_RESULT)

--- a/core-lib/src/main/java/org/idpass/smartscanner/lib/nfc/details/IntentData.kt
+++ b/core-lib/src/main/java/org/idpass/smartscanner/lib/nfc/details/IntentData.kt
@@ -20,6 +20,7 @@ package org.idpass.smartscanner.lib.nfc.details
 object IntentData {
     val KEY_IMAGE = "KEY_IMAGE"
     val KEY_LANGUAGE = "KEY_LANGUAGE"
+    val KEY_LABEL = "KEY_LABEL"
     val KEY_LOCALE = "KEY_LOCALE"
     val KEY_MRZ_INFO = "KEY_MRZ_INFO"
     val KEY_PASSPORT = "KEY_PASSPORT"

--- a/core-lib/src/main/java/org/idpass/smartscanner/lib/scanner/config/NFCOptions.kt
+++ b/core-lib/src/main/java/org/idpass/smartscanner/lib/scanner/config/NFCOptions.kt
@@ -22,9 +22,10 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class NFCOptions(
+    val label: String? = null,
     val locale: String? = null,
     val withPhoto: Boolean? = null,
-    val enableLogging: Boolean? = null,
+    val enableLogging: Boolean? = null
 ) : Parcelable {
     companion object {
         val default = NFCOptions(


### PR DESCRIPTION
## Issue

<!-- Provide a reference to the issue that this change is going to address -->
<!-- E.g. #12 Issue title here -->

#72 Option for NFC Reader label to be configurable 

## Changes

<!-- Provide a detailed description of the changes proposed in this PR -->

- Add Option for NFC Reader label to be configurable
- Link NFC Screen label to analyzer classes
- Add label field to NFCOptions config
- Disable code block on capture logs of full APDU command/response
