### PR TITLE
Handle date parsing for 2 digits year

### DIFF
--- a/core-lib/src/main/java/org/idpass/smartscanner/lib/nfc/NFCFragment.kt
+++ b/core-lib/src/main/java/org/idpass/smartscanner/lib/nfc/NFCFragment.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import android.content.Intent
 import android.nfc.NfcAdapter
 import android.nfc.Tag
+import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -31,6 +32,7 @@ import android.view.ViewGroup
 import android.widget.ProgressBar
 import android.widget.TextView
 import android.widget.Toast
+import androidx.annotation.RequiresApi
 import androidx.fragment.app.Fragment
 import io.reactivex.disposables.CompositeDisposable
 import net.sf.scuba.smartcards.CardServiceException
@@ -41,6 +43,8 @@ import org.idpass.smartscanner.lib.nfc.details.NFCDocumentTag
 import org.idpass.smartscanner.lib.nfc.passport.Passport
 import org.idpass.smartscanner.lib.scanner.config.Language
 import org.idpass.smartscanner.lib.utils.DateUtils
+import org.idpass.smartscanner.lib.utils.DateUtils.BIRTH_DATE_THRESHOLD
+import org.idpass.smartscanner.lib.utils.DateUtils.EXPIRY_DATE_THRESHOLD
 import org.idpass.smartscanner.lib.utils.DateUtils.formatStandardDate
 import org.idpass.smartscanner.lib.utils.KeyStoreUtils
 import org.idpass.smartscanner.lib.utils.LanguageUtils
@@ -183,6 +187,7 @@ class NFCFragment : Fragment() {
         super.onDetach()
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
     override fun onResume() {
         super.onResume()
         // Display proper language
@@ -190,8 +195,8 @@ class NFCFragment : Fragment() {
         // Display MRZ details
         textViewNfcTitle?.text = if (label != null) label else getString(R.string.nfc_title)
         textViewPassportNumber?.text = getString(R.string.doc_number, mrzInfo?.documentNumber)
-        textViewDateOfBirth?.text = getString(R.string.doc_dob, DateUtils.toAdjustedDate(formatStandardDate(mrzInfo?.dateOfBirth)))
-        textViewDateOfExpiry?.text = getString(R.string.doc_expiry, DateUtils.toReadableDate(formatStandardDate(mrzInfo?.dateOfExpiry)))
+        textViewDateOfBirth?.text = getString(R.string.doc_dob, DateUtils.toAdjustedDate(formatStandardDate(mrzInfo?.dateOfBirth, threshold = BIRTH_DATE_THRESHOLD)))
+        textViewDateOfExpiry?.text = getString(R.string.doc_expiry, DateUtils.toReadableDate(formatStandardDate(mrzInfo?.dateOfExpiry, threshold = EXPIRY_DATE_THRESHOLD)))
 
         if (nfcFragmentListener != null) {
             nfcFragmentListener?.onEnableNfc()

--- a/core-lib/src/main/java/org/idpass/smartscanner/lib/nfc/NFCResult.kt
+++ b/core-lib/src/main/java/org/idpass/smartscanner/lib/nfc/NFCResult.kt
@@ -17,9 +17,13 @@
  */
 package org.idpass.smartscanner.lib.nfc
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import org.idpass.smartscanner.lib.nfc.passport.Passport
 import org.idpass.smartscanner.lib.scanner.config.Language.Locale
 import org.idpass.smartscanner.lib.utils.DateUtils
+import org.idpass.smartscanner.lib.utils.DateUtils.BIRTH_DATE_THRESHOLD
+import org.idpass.smartscanner.lib.utils.DateUtils.EXPIRY_DATE_THRESHOLD
 import org.idpass.smartscanner.lib.utils.DateUtils.formatStandardDate
 import org.idpass.smartscanner.lib.utils.LanguageUtils.isRTL
 import org.idpass.smartscanner.lib.utils.extension.arrayToString
@@ -54,6 +58,7 @@ data class NFCResult(
 ) {
     companion object {
 
+        @RequiresApi(Build.VERSION_CODES.O)
         fun formatResult(passport: Passport?, locale: String?, mrzInfo: MRZInfo? = null, image: String? = null, mrzImage: String? = null): NFCResult {
             val personDetails = passport?.personDetails
             val additionalPersonDetails = passport?.additionalPersonDetails
@@ -102,9 +107,9 @@ data class NFCResult(
                 }
             }
             // Get proper date of birth
-            val dateOfBirth = if (additionalPersonDetails?.fullDateOfBirth.isNullOrEmpty()) {
-                DateUtils.toAdjustedDate (formatStandardDate(personDetails?.dateOfBirth))
-            } else formatStandardDate(additionalPersonDetails?.fullDateOfBirth, "yyyyMMdd")
+           val dateOfBirth = if (additionalPersonDetails?.fullDateOfBirth.isNullOrEmpty()) {
+               DateUtils.toAdjustedDate (formatStandardDate(personDetails?.dateOfBirth, threshold = BIRTH_DATE_THRESHOLD))
+           } else formatStandardDate(additionalPersonDetails?.fullDateOfBirth, "yyyyMMdd")
             return NFCResult(
                     image = image,
                     mrzImage = mrzImage,
@@ -113,7 +118,7 @@ data class NFCResult(
                     nameOfHolder = additionalPersonDetails?.nameOfHolder,
                     gender = personDetails?.gender?.name,
                     documentNumber = personDetails?.documentNumber,
-                    dateOfExpiry = DateUtils.toReadableDate(formatStandardDate(personDetails?.dateOfExpiry)),
+                    dateOfExpiry = DateUtils.toReadableDate(formatStandardDate(personDetails?.dateOfExpiry, threshold = EXPIRY_DATE_THRESHOLD)),
                     issuingState = personDetails?.issuingState,
                     nationality = personDetails?.nationality,
                     otherNames = additionalPersonDetails?.otherNames?.arrayToString(),

--- a/core-lib/src/main/java/org/idpass/smartscanner/lib/nfc/passport/PassportDetailsFragment.kt
+++ b/core-lib/src/main/java/org/idpass/smartscanner/lib/nfc/passport/PassportDetailsFragment.kt
@@ -20,11 +20,13 @@ package org.idpass.smartscanner.lib.nfc.passport
 import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Bitmap
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
+import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
 import org.idpass.smartscanner.lib.R
 import org.idpass.smartscanner.lib.databinding.FragmentPassportDetailsBinding
@@ -88,6 +90,7 @@ class PassportDetailsFragment : androidx.fragment.app.Fragment() {
         refreshData(passport)
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
     @SuppressLint("SetTextI18n")
     private fun refreshData(passport: Passport?) {
         if (passport == null) return


### PR DESCRIPTION
## Issue

Date parsing for 2 digits when using SimpleDateFormat returns unexpected birth date
Example:
 ```yyMMdd 420101 -> dd/MM/yyyy 01/01/2042 ```

https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html

## Solution:
Add a starting year by using `SimpleDateFormat.set2DigitYearStart`, the exact year will be calculated be a threshold number.

Example:

- Birth Date: Start date will be 99 years ago from the present year e.g. 2023 - 99 = 1924. It means the lowest year will be 1924 and highest will be 2023.

```
240101 -> 01/01/1924
230101 -> 01/01/2023
```

- Expiry Date: Start date will be 49 years ago from the present year e.g. 2023-49 = 1974.

```
740101 -> 01/01/1974
730101 -> 01/01/2073
```

You can quick check the logic here in this online editor [link](https://pl.kotl.in/vLaODShL9)

## Changes

<!-- Provide a detailed description of the changes proposed in this PR -->

1. Add new func stringToDate2DigitsYear to handle 2 digits year.
1. Add threshold number for birth date and expiry date.
1. Add new param to where it's using the default format yyMMdd
